### PR TITLE
Added Artisan-Style Output for CRUD File Generation

### DIFF
--- a/src/Commands/SmartScaffoldCommand.php
+++ b/src/Commands/SmartScaffoldCommand.php
@@ -16,6 +16,9 @@ class SmartScaffoldCommand extends Command
         $modelName = $this->argument('model');
         $fields = $this->option('fields');
 
+        $this->info("Generating CRUD files for {$modelName}...");
+        $this->newLine(); 
+
         // Generate Response Trait
         $this->generateResponseTrait();
 
@@ -30,17 +33,15 @@ class SmartScaffoldCommand extends Command
             $this->generateMigration($modelName, $fields);
             $this->generateFactory($modelName, $fields);
             $this->generateRequestFiles($modelName, $fields);
+            $this->printCreatedFile(app_path("Http/Requests/Store{$modelName}Request.php"));
+            $this->printCreatedFile(app_path("Http/Requests/Update{$modelName}Request.php"));
             $this->generateResources($modelName, $fields);
+            $this->printCreatedFile(app_path("Http/Resources/{$modelName}Resource.php"));
             $this->generateFilters($modelName, $fields);
         }
 
         // Add API Resource Route
         $this->addApiResourceRoute($modelName);
-
-        $this->info("CRUD files for {$modelName} created successfully!");
-        if ($fields) {
-            $this->info("Migration file created with fields: {$fields}");
-        }
     }
 
     protected function generateModel($modelName)
@@ -58,6 +59,7 @@ class SmartScaffoldCommand extends Command
         );
         File::ensureDirectoryExists(dirname($modelPath));
         File::put($modelPath, $content);
+        $this->printCreatedFile(app_path("Models/{$modelName}.php"));
     }
 
     protected function generateMigration($modelName, $fields)
@@ -78,6 +80,7 @@ class SmartScaffoldCommand extends Command
         );
 
         File::put($migrationPath, $content);
+        $this->printCreatedFile(database_path("migrations/{$timestamp}_{$migrationName}.php"));
     }
 
     protected function buildSchemaContent($fields)
@@ -214,6 +217,7 @@ class SmartScaffoldCommand extends Command
         
         File::ensureDirectoryExists(dirname($factoryPath));
         File::put($factoryPath, $content);
+        $this->printCreatedFile(database_path("factories/{$modelName}Factory.php"));
     }
 
     protected function getFactoryFieldDefinition($name, $type)
@@ -326,6 +330,7 @@ class SmartScaffoldCommand extends Command
         $stub = File::get(__DIR__ . '/../../resources/stubs/response-trait.stub');
 
         File::put($traitPath, $stub);
+        $this->printCreatedFile(app_path("Traits/Response.php"));
     }
 
 
@@ -356,6 +361,7 @@ class SmartScaffoldCommand extends Command
 
         File::ensureDirectoryExists(dirname($controllerPath));
         File::put($controllerPath, $content);
+        $this->printCreatedFile(app_path("Http/Controllers/{$modelName}Controller.php"));
     }
 
     protected function generateFieldMappings($fields)
@@ -447,6 +453,7 @@ class SmartScaffoldCommand extends Command
                 $filterPath,
                 File::get(__DIR__.'/../../resources/stubs/query-filter.stub')
             );
+            $this->printCreatedFile(app_path("Filters/QueryFilter.php"));
         }
     }
 
@@ -474,6 +481,7 @@ class SmartScaffoldCommand extends Command
 
         File::ensureDirectoryExists(dirname($filterPath));
         File::put($filterPath, $content);
+        $this->printCreatedFile(app_path("Filters/{$modelName}Filter.php"));
     }
 
     protected function generateFilterMethod($fieldName, $fieldType)
@@ -517,5 +525,11 @@ class SmartScaffoldCommand extends Command
         $method .= "}";
         
         return $method;
+    }
+
+    protected function printCreatedFile($path)
+    {
+        $relativePath = str_replace(base_path().'/', '', $path);
+        $this->line("<fg=green>Created</> {$relativePath}");
     }
 }

--- a/src/Commands/SmartScaffoldCommand.php
+++ b/src/Commands/SmartScaffoldCommand.php
@@ -33,10 +33,7 @@ class SmartScaffoldCommand extends Command
             $this->generateMigration($modelName, $fields);
             $this->generateFactory($modelName, $fields);
             $this->generateRequestFiles($modelName, $fields);
-            $this->printCreatedFile(app_path("Http/Requests/Store{$modelName}Request.php"));
-            $this->printCreatedFile(app_path("Http/Requests/Update{$modelName}Request.php"));
             $this->generateResources($modelName, $fields);
-            $this->printCreatedFile(app_path("Http/Resources/{$modelName}Resource.php"));
             $this->generateFilters($modelName, $fields);
         }
 
@@ -244,6 +241,7 @@ class SmartScaffoldCommand extends Command
             'Store', 
             $fieldDefinitions
         );
+        $this->printCreatedFile(app_path("Http/Requests/Store{$modelName}Request.php"));
         
         // Generate Update Request (now same as Store)
         $this->generateRequestFile(
@@ -251,6 +249,7 @@ class SmartScaffoldCommand extends Command
             'Update', 
             $fieldDefinitions
         );
+        $this->printCreatedFile(app_path("Http/Requests/Update{$modelName}Request.php"));
     }
 
     protected function generateRequestFile($modelName, $type, $fields)
@@ -415,6 +414,7 @@ class SmartScaffoldCommand extends Command
 
         File::ensureDirectoryExists(dirname($resourcePath));
         File::put($resourcePath, $content);
+        $this->printCreatedFile(app_path("Http/Resources/{$modelName}Resource.php"));
     }
 
     protected function generateResourceCollection($modelName)
@@ -430,6 +430,7 @@ class SmartScaffoldCommand extends Command
 
         File::ensureDirectoryExists(dirname($collectionPath));
         File::put($collectionPath, $content);
+        $this->printCreatedFile(app_path("Http/Resources/{$modelName}Collection.php"));
     }
 
 


### PR DESCRIPTION
### Summary:
Enhanced the `make:crud` command by adding detailed console output that mimics Laravel's native artisan command behavior. This provides clear feedback to the developer by listing all generated files after the command is executed.

### Changes Introduced:
- Added `info()` output messages after each file is created.
- Output format follows Laravel's artisan style (e.g., `Created app/Models/Post.php`).
- Introduced "Generating..." intro message and newline spacing for clarity.

### Sample Output:
Command:
php artisan make:crud Category --fields='name:string, slug:string, description:text'

Output:
Generating CRUD files for Category...

Created app/Traits/Response.php  
Created app/Models/Category.php  
Created app/Http/Controllers/CategoryController.php  
Created database/migrations/xxxx_xx_xx_create_categories_table.php  
Created database/factories/CategoryFactory.php  
Created app/Http/Requests/StoreCategoryRequest.php  
Created app/Http/Requests/UpdateCategoryRequest.php  
Created app/Http/Resources/CategoryResource.php  
Created app/Filters/QueryFilter.php  
Created app/Filters/CategoryFilter.php  

### Why:
This improves developer experience by:
- Mimicking Laravel’s native command-line behavior
- Providing instant feedback and visibility into what was generated
- Helping users debug or confirm scaffolding success

No breaking changes were introduced.
